### PR TITLE
feat: implementar enum EstadoPartida con Javadoc

### DIFF
--- a/Programa/src/Modelo/EstadoPartida.java
+++ b/Programa/src/Modelo/EstadoPartida.java
@@ -1,0 +1,17 @@
+package Modelo;
+
+/**
+ * Enum que representa los posibles estados de una partida.
+ *
+ * @author JP-Aceves
+ * @version 1.0
+ */
+public enum EstadoPartida {
+    /** La partida está en curso. */
+    EN_CURSO,
+    /** La partida está pausada. */
+    PAUSADA,
+    /** La partida ha finalizado. */
+    FINALIZADA
+}
+


### PR DESCRIPTION
Implementado el enum EstadoPartida con:
- Tres estados: EN_CURSO, PAUSADA, FINALIZADA
- Javadoc añadido en la clase y en cada constante

Cierra #22