### PR TITLE
feat: implementar interfaz GestorPersistencia con Javadoc

### DIFF
--- a/Programa/src/Persistencia/GestorPersistencia.java
+++ b/Programa/src/Persistencia/GestorPersistencia.java
@@ -1,0 +1,38 @@
+package Persistencia;
+
+import Modelo.Usuario;
+import Modelo.Estadistica;
+import java.util.ArrayList;
+
+/**
+ * Interfaz que define el contrato para la persistencia de datos.
+ *
+ * @author JP-Aceves
+ * @version 1.0
+ */
+public interface GestorPersistencia {
+
+    /** Guarda la lista completa de usuarios en el fichero. */
+    void guardarUsuarios(ArrayList<Usuario> listaUsuarios);
+
+    /** Carga y devuelve la lista de usuarios del fichero. */
+    ArrayList<Usuario> cargarUsuarios();
+
+    /** Añade una estadística al fichero de estadísticas. */
+    void agregarEstadistica(Estadistica e);
+
+    /** Carga y devuelve todas las estadísticas del fichero. */
+    ArrayList<Estadistica> cargarEstadisticas();
+
+    /** Guarda el estado serializado de una partida pausada. */
+    void guardarPartidaPausada(int id, String estado);
+
+    /** Carga el estado de una partida pausada por su id. */
+    String cargarPartidaPausada(int id);
+
+    /** Elimina el fichero de una partida pausada. */
+    void eliminarPartidaPausada(int id);
+
+    /** Lista los ids de todas las partidas pausadas. */
+    ArrayList<Integer> listarPartidasPausadas();
+}


### PR DESCRIPTION
Define el contrato de persistencia que toda la aplicación usa para leer y escribir datos.

Qué incluye:

- Interfaz GestorPersistencia con todos los métodos del contrato: guardarUsuarios, cargarUsuarios, agregarEstadistica, cargarEstadisticas, guardarPartidaPausada, cargarPartidaPausada, eliminarPartidaPausada y listarPartidasPausadas

- Javadoc en cada método: parámetros, retorno y posibles excepciones

- Sin implementación (eso va en PersistenciaArchivos, issue #15)

Por qué es interfaz y no clase:
Desacopla el contrato de la implementación. Si mañana se cambia de ficheros de texto a base de datos, solo se crea una nueva clase que implemente esta interfaz. El resto del código no cambia.

Cierra #6 