### PR TITLE
fix: eliminar parámetro fecha de iniciarPartida y llamada al constructor

### DIFF
--- a/Programa/src/Controlador/GestorPartidas.java
+++ b/Programa/src/Controlador/GestorPartidas.java
@@ -70,9 +70,9 @@ public class GestorPartidas {
      * @param fecha     fecha de inicio de la partida
      * @return la {@link Partida} recién creada
      */
-    public Partida iniciarPartida(Juego juego, ArrayList<Usuario> jugadores, String fecha) {
+    public Partida iniciarPartida(Juego juego, ArrayList<Usuario> jugadores) {
         juego.inicializar();
-        partidaActual = new Partida(++contadorId, juego, fecha, jugadores);
+        partidaActual = new Partida(++contadorId, juego, jugadores);
         return partidaActual;
     }
 


### PR DESCRIPTION
El constructor de Partida genera la fecha internamente con LocalDate.now(), 
por lo que el parámetro String fecha en iniciarPartida() era redundante y 
causaba un error de compilación al llamar a new Partida().

- Eliminado String fecha de la firma de iniciarPartida()
- Corregida la llamada al constructor: new Partida(++contadorId, juego, jugadores)